### PR TITLE
add ThredUP's talk about lessons learned during migration to k8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Most recent publications on top.
 * [Major Outage: Current account payments mail fail - Monzo - Monzo Community post 2017](https://community.monzo.com/t/resolved-current-account-payments-may-fail-major-outage-27-10-2017/26296/95)
 * [Our First Kubernetes Outage - Saltside - blog post 2017](https://engineering.saltside.se/our-first-kubernetes-outage-c6b9249cfd3a)
 * [Our Failure Migrating to Kubernetes - Saltside - blog post 2017](https://engineering.saltside.se/our-failure-migrating-to-kubernetes-25c28e6dd604)
+* [Moving the Entire Stack to K8S Within a Year – Lessons Learned - ThredUP - DevOpsStage 2018](https://www.youtube.com/watch?v=tA8Sr3Nsx1I)
 
 
 # Why


### PR DESCRIPTION
I've added a link to ThredUP's talk about migrating it's services to Kubernetes. During migration we faced a lot of issues both in k8s toolset and in applications, which work with and within k8s.