### PR TITLE
Add dex/CR/bad defaults failure story

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 A compiled list of links to public failure stories related to Kubernetes.
 Most recent publications on top.
 
+* [A Kubernetes failure story (dex) - anonymous Fullstaq client - Dutch kubernetes meetup slides 2019-06](https://pieterlange.github.io/failure-stories/2019-06.dex.html)
+    * involved: etcd, apiserver, dex, custom resources
+    * impact: broken control plane on production with no access to o11y due to broken authentication system, no actual business impact
 * [A Kubernetes crime story - Prezi - blog post 2019](https://engineering.prezi.com/https-engineering-prezi-com-a-kubernetes-crime-story-2e8d75a77630)
     * involved: AWS EKS, SNAT, conntrack, Amazon VPC CNI plugin
     * impact: delay of 1-3 seconds for outgoing TCP connections
@@ -129,9 +132,6 @@ Most recent publications on top.
 * [SaleMove US System Issue - SaleMove - incident report 2017](https://status.salemove.com/incidents/xf6cr710yrzn)
     * involved: AWS, ELB dynamic IPs, DNS `A` record for master, API server
     * impact: production issues with SaleMove US System
-* [A kubernetes failure story (dex) - Dutch kubernetes meetup slides 2019-06](https://pieterlange.github.io/failure-stories/2019-06.dex.html)
-    * involved: etcd, apiserver, dex, custom resources
-    * impact: broken control plane on production with no access to o11y due to broken authentication system, no actual business impact
 
 # Why
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Most recent publications on top.
 * [SaleMove US System Issue - SaleMove - incident report 2017](https://status.salemove.com/incidents/xf6cr710yrzn)
     * involved: AWS, ELB dynamic IPs, DNS `A` record for master, API server
     * impact: production issues with SaleMove US System
+* [A kubernetes failure story (dex) - Dutch kubernetes meetup slides 2019-06](https://pieterlange.github.io/failure-stories/2019-06.dex.html)
+    * involved: etcd, apiserver, dex, custom resources
+    * impact: broken control plane on production with no access to o11y due to broken authentication system, no actual business impact
 
 # Why
 


### PR DESCRIPTION
Slides for my failure story related to the [default](https://github.com/helm/charts/blob/master/stable/dex/values.yaml#L141) [dex](https://github.com/dexidp/dex/) configuration storing authrequests as CustomResources and its potential for nuking your kubernetes control plane.

The link: https://pieterlange.github.io/failure-stories/2019-06.dex.html
Ref: https://github.com/dexidp/dex/issues/1292
Shared at: https://www.meetup.com/Dutch-Kubernetes-Meetup/events/262313920/